### PR TITLE
fix gap between table and keyboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -275,7 +275,7 @@ function App() {
         setIsSettingsModalOpen={setIsSettingsModalOpen}
       />
       <div className="pt-2 px-1 pb-8 md:max-w-7xl w-full mx-auto sm:px-6 lg:px-8 flex flex-col grow">
-        <div className="pb-6 grow">
+        <div className="pb-6">
           <Grid
             guesses={guesses}
             currentGuess={currentGuess}


### PR DESCRIPTION
There is a huge gap between the grid and the keyboard on some mobile devices. The user has to scroll down to see all the letters on the keyboard. The screenshot is from an Iphone 13 pro


![screenshot](https://user-images.githubusercontent.com/33469024/161595908-725c76ab-b9e0-4362-aa55-49ecc53d09e9.png)
 